### PR TITLE
Feat/documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Observer core
 
+## 🚀 0.16.0 - 11/10/2024
+### Nouveautés
+
+- Pas de nouveautés.
+
+### Changements
+
+- Ajout d'un message obligatoire quand le token est invalide.
+- Ajout d'un nouveau state `DocumentWithErrorPage` pour montrer les érreurs dans une page.
+- Les failures seront gérer uniquement pour les listeners.
+- Ajout des states loading au début des méthodes.
+
+### Correctifs
+
+- Mise à jour du selector. Le state `CategoriesAreFilteredSuccessfully` n'était géré et causait des érreurs en front.
+
+
 ## 🚀 0.15.0 - 07/10/2024
 ### Nouveautés
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Owner](https://img.shields.io/badge/Owner-Samakunchan%20Technology-blue)](https://samakunchan-technology.com/)
-[![Owner](https://img.shields.io/badge/OBSERVER--CORE-v0.15.0-orange)](https://samakunchan-technology.com/)
+[![Owner](https://img.shields.io/badge/OBSERVER--CORE-v0.16.0-orange)](https://samakunchan-technology.com/)
 ## Features
 
 Ceci est le core de mon projet dashboard.

--- a/lib/features/authentication/tokens/bloc/auth_token_bloc.dart
+++ b/lib/features/authentication/tokens/bloc/auth_token_bloc.dart
@@ -18,7 +18,7 @@ class AuthTokenBloc extends Bloc<AuthTokenEvent, AuthTokenState> {
   }
 
   FutureOr<void> _onInValidToken(AuthTokenInValidDetected event, Emitter<AuthTokenState> emit) async {
-    emit.call(AuthTokenInvalid());
+    emit.call(AuthTokenInvalid(message: event.message));
   }
 
   FutureOr<void> _onTestValidityToken(AuthTokenTestAvailability event, Emitter<AuthTokenState> emit) async {

--- a/lib/features/authentication/tokens/bloc/auth_token_event.dart
+++ b/lib/features/authentication/tokens/bloc/auth_token_event.dart
@@ -12,10 +12,12 @@ class AuthTokenValidDetected extends AuthTokenEvent {
 }
 
 class AuthTokenInValidDetected extends AuthTokenEvent {
-  const AuthTokenInValidDetected();
+  const AuthTokenInValidDetected({required this.message});
+
+  final String message;
 
   @override
-  List<Object?> get props => [];
+  List<Object?> get props => [message];
 }
 
 class AuthTokenTestAvailability extends AuthTokenEvent {

--- a/lib/features/authentication/tokens/bloc/auth_token_state.dart
+++ b/lib/features/authentication/tokens/bloc/auth_token_state.dart
@@ -15,8 +15,12 @@ final class AuthTokenValid extends AuthTokenState {
 }
 
 final class AuthTokenInvalid extends AuthTokenState {
+  const AuthTokenInvalid({required this.message});
+
+  final String message;
+
   @override
-  List<Object> get props => [];
+  List<Object> get props => [message];
 }
 
 final class AuthTokenValidityIsTested extends AuthTokenState {

--- a/lib/features/category/selectors/categories_selector.dart
+++ b/lib/features/category/selectors/categories_selector.dart
@@ -24,18 +24,29 @@ class CategoriesSelector extends StatelessWidget {
   }
 
   List<CategoryModel> _getListCategories(CategoryState state) {
-    if (state is CategoriesAreLoadedSuccessfully) {
-      final List<CategoryModel> categoryProjects =
-          state.categories.where((CategoryModel category) => category.environment?.title == 'Portfolio').toList();
+    switch (state) {
+      case CategoriesAreLoadedSuccessfully():
+        final List<CategoryModel> categoryProjects =
+            state.categories.where((CategoryModel category) => category.environment?.title == 'Portfolio').toList();
 
-      final CategoryModel selectedCategory =
-          categoryProjects.where((CategoryModel category) => category.id == idCategoryProject).toList().first;
+        final CategoryModel selectedCategory =
+            categoryProjects.where((CategoryModel category) => category.id == idCategoryProject).toList().first;
 
-      onInit(selectedCategory);
+        onInit(selectedCategory);
 
-      return categoryProjects;
-    } else {
-      return [];
+        return categoryProjects;
+      case CategoriesAreFilteredSuccessfully():
+        final List<CategoryModel> categoryProjects =
+            state.categories.where((CategoryModel category) => category.environment?.title == 'Portfolio').toList();
+
+        final CategoryModel selectedCategory =
+            categoryProjects.where((CategoryModel category) => category.id == idCategoryProject).toList().first;
+
+        onInit(selectedCategory);
+
+        return categoryProjects;
+      default:
+        return [];
     }
   }
 }

--- a/lib/features/document/bloc/main/document_event.dart
+++ b/lib/features/document/bloc/main/document_event.dart
@@ -131,3 +131,25 @@ class DocumentsFailed extends DocumentEvent {
   @override
   List<Object?> get props => [message];
 }
+
+class DocumentsErrorPageShown extends DocumentEvent {
+  const DocumentsErrorPageShown({this.message = ErrorMessage.noErrorMessageHandled});
+
+  /// Tout les messages d'érreurs:
+  /// - [ErrorMessage.noErrorMessageHandled]
+  /// - [ErrorMessage.networkOfflineMessage]
+  /// - [ErrorMessage.serverFailureMessage]
+  /// - [ErrorMessage.cacheFailureMessage]
+  /// - [ErrorMessage.notFoundMessage]
+  /// - [ErrorMessage.unAuthorizationMessage]
+  /// - [ErrorMessage.forbiddenMessage]
+  final String message;
+
+  @override
+  List<Object> get props => [message];
+}
+
+class DocumentsOnReconnect extends DocumentEvent {
+  @override
+  List<Object?> get props => [];
+}

--- a/lib/features/document/bloc/main/document_state.dart
+++ b/lib/features/document/bloc/main/document_state.dart
@@ -89,3 +89,25 @@ class DocumentFormIsDeletedSuccessfully extends DocumentState {
   @override
   List<Object> get props => [];
 }
+
+class DocumentWithErrorPage extends DocumentState {
+  const DocumentWithErrorPage({this.message = ErrorMessage.noErrorMessageHandled});
+
+  /// Tout les messages d'érreurs:
+  /// - [ErrorMessage.noErrorMessageHandled]
+  /// - [ErrorMessage.networkOfflineMessage]
+  /// - [ErrorMessage.serverFailureMessage]
+  /// - [ErrorMessage.cacheFailureMessage]
+  /// - [ErrorMessage.notFoundMessage]
+  /// - [ErrorMessage.unAuthorizationMessage]
+  /// - [ErrorMessage.forbiddenMessage]
+  final String message;
+
+  @override
+  List<Object> get props => [message];
+}
+
+class DocumentsIsReconnecting extends DocumentState {
+  @override
+  List<Object?> get props => [];
+}

--- a/lib/features/project/bloc/project_bloc.dart
+++ b/lib/features/project/bloc/project_bloc.dart
@@ -66,7 +66,7 @@ class ProjectBloc extends Bloc<ProjectEvent, ProjectState> {
       ),
     );
 
-    await ProjectHandler.withReponse(
+    await ProjectHandler.withResponse(
       responses: responses,
       ifFailure: (Failure failure) => ProjectHandler.handleAllFailures(failure: failure, emit: emit),
       ifSuccess: (HttpResponse<dynamic> response) => ProjectHandler.handleDeleteSuccess(response: response, emit: emit),
@@ -110,7 +110,7 @@ class ProjectBloc extends Bloc<ProjectEvent, ProjectState> {
       ),
     );
 
-    await DocumentHandler.withReponse(
+    await ProjectHandler.withResponse(
       responses: responses,
       ifFailure: (Failure failure) => ProjectHandler.handleAllFailures(failure: failure, emit: emit),
       ifSuccess: (HttpResponse<dynamic> response) => ProjectHandler.handleUpsertSuccess(response: response, emit: emit),
@@ -150,7 +150,7 @@ class ProjectBloc extends Bloc<ProjectEvent, ProjectState> {
 class ProjectHandler {
   const ProjectHandler._();
 
-  static Future<void> withReponse({
+  static Future<void> withResponse({
     required Either<Failure, HttpResponse<dynamic>> responses,
     required ValueChanged<Failure> ifFailure,
     required ValueChanged<HttpResponse<dynamic>> ifSuccess,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: observer_core
 description: Ce projet contient les models et le dialogue avec l'API.
-version: 0.15.0
+version: 0.16.0
 homepage: https://github.com/samakunchan/observer_core
 
 environment:


### PR DESCRIPTION
## 🚀 0.16.0 - 11/10/2024
### Nouveautés

- Pas de nouveautés.

### Changements

- Ajout d'un message obligatoire quand le token est invalide.
- Ajout d'un nouveau state `DocumentWithErrorPage` pour montrer les érreurs dans une page.
- Les failures seront gérer uniquement pour les listeners.
- Ajout des states loading au début des méthodes.

### Correctifs

- Mise à jour du selector. Le state `CategoriesAreFilteredSuccessfully` n'était géré et causait des érreurs en front.